### PR TITLE
Add HasEndpoint instance for NamedRoutes

### DIFF
--- a/src/OpenTelemetry/Instrumentation/Servant/Internal.hs
+++ b/src/OpenTelemetry/Instrumentation/Servant/Internal.hs
@@ -8,6 +8,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
+-- NOTE: This is required in implementing HasEndpoint instance for NamedRoutes.
+#if MIN_VERSION_servant(0,19,0)
+{-# LANGUAGE UndecidableInstances #-}
+#endif
+
 -- Adapted from https://github.com/haskell-servant/servant-ekg
 --
 -- Copyright (c) 2015, Anchor Systems
@@ -185,3 +190,8 @@ instance (HasEndpoint (sub :: Type)) => HasEndpoint (CaptureAll (h :: Symbol) a 
 
 instance (HasEndpoint (sub :: Type)) => HasEndpoint (BasicAuth (realm :: Symbol) a :> sub) where
   getEndpoint _ = getEndpoint (Proxy :: Proxy sub)
+
+#if MIN_VERSION_servant(0,19,0)
+instance (HasEndpoint (ToServantApi api)) => HasEndpoint (NamedRoutes api) where
+  getEndpoint _ req = getEndpoint (Proxy :: Proxy (ToServantApi api)) req
+#endif


### PR DESCRIPTION
This PR adds `HasEndpoint` instance for `NamedRoutes`.
I've tested this instance on an internal project where we are currently maintaining an orphan instance.

Is there any more information required from me to make the merge process easier?

Please note that although I've added a CPP constraint, I did not get a chance to test the build with `0.19` as other functions in the package break.