### PR TITLE
fix: update OpenTelemetry collector command from otelcontribcol to otelcol-contrib

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -15,7 +15,7 @@
 
   processes = {
     opentelemetry-collector.exec =
-      "otelcontribcol --config ./exe/otelconfig.yaml";
+      "otelcol-contrib --config ./exe/otelconfig.yaml";
 
     server.exec =
       "ghcid -c 'cabal repl exe:server' --test main";


### PR DESCRIPTION
The otelcontribcol command is outdated and causes "command not found" errors.
The opentelemetry-collector-contrib package now installs the binary as otelcol-contrib.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)